### PR TITLE
Return a string containing the binary sid structure

### DIFF
--- a/test/test_sid.rb
+++ b/test/test_sid.rb
@@ -59,6 +59,10 @@ class TC_Win32_Security_Sid < Test::Unit::TestCase
     assert_kind_of(String, Security::SID.string_to_sid(@sid.to_s))
   end
 
+  test "string/sid roundtrip works as expected" do
+    assert_true(Security::SID.new(Security::SID.string_to_sid('S-1-5-18')).to_s == 'S-1-5-18')
+  end
+
   test "to_s works as expected" do
     assert_respond_to(@sid, :to_s)
     assert_kind_of(String, @sid.to_s)


### PR DESCRIPTION
Previously, the `string_to_sid` method was returning a string containing
the address of the sid structure, possibly truncated due to the
`String#strip` call. For example, if the address was "\001\002\003\000",
then the resulting string would be "\001\002\003"

Since the `string_to_sid` method returned the address of the sid
structure, passing that to `SID.new` would fail, as it expects a string
containing the binary sid structure.
